### PR TITLE
Enhance popup UI using reference design

### DIFF
--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,16 +1,32 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
+  <meta charset="UTF-8">
   <title>Sisypi</title>
-  <link rel="stylesheet" href="styles.css" />
+  <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-  <h1>Sisypi</h1>
-  <button id="start-recording">⏺️ Kayıt Başlat</button>
-  <button id="stop-recording">⏹️ Durdur</button>
-  <button id="add-wait">⏱️ Wait</button>
-  <button id="add-copy">📋 Copy</button>
-  <ul id="scenario-list"></ul>
+  <div class="container">
+    <header class="header">
+      <h1>Sisypi</h1>
+      <div>
+        <input type="file" id="import-input" style="display:none" accept=".json">
+        <button id="import-btn" class="button-secondary">Import</button>
+        <button id="new-scenario-btn">New Scenario</button>
+      </div>
+    </header>
+    <main>
+      <div class="record-button-wrapper">
+        <div id="recording-status" class="recording-status" style="display:none">Recording...</div>
+        <button id="toggle-recording" class="record-button button-secondary">Start Recording</button>
+        <div style="margin-top:8px;text-align:center;">
+          <button id="add-wait" class="button-secondary" style="margin-right:4px;">⏱️ Wait</button>
+          <button id="add-copy" class="button-secondary">📋 Copy</button>
+        </div>
+      </div>
+      <ul id="scenario-list" class="scenario-list"></ul>
+    </main>
+  </div>
   <script src="storage.js"></script>
   <script src="popup.js"></script>
 </body>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,24 +1,40 @@
-// Handles popup UI logic for Sisypi
-
-const startBtn = document.getElementById('start-recording');
-const stopBtn = document.getElementById('stop-recording');
+// Handles popup UI logic for Sisypi with improved UI
+const toggleBtn = document.getElementById('toggle-recording');
+const recordingStatusEl = document.getElementById('recording-status');
+const newScenarioBtn = document.getElementById('new-scenario-btn');
+const importBtn = document.getElementById('import-btn');
+const importInput = document.getElementById('import-input');
 const addWaitBtn = document.getElementById('add-wait');
 const addCopyBtn = document.getElementById('add-copy');
 const listEl = document.getElementById('scenario-list');
 
 let currentName = null;
+let recording = false;
 
-startBtn.addEventListener('click', () => {
-  const name = prompt('Scenario name?');
-  if (!name) return;
-  currentName = name;
-  chrome.runtime.sendMessage({ type: 'startRecording', name });
-});
+function updateRecordingUI() {
+  if (recording) {
+    recordingStatusEl.style.display = 'block';
+    toggleBtn.textContent = 'Stop Recording';
+  } else {
+    recordingStatusEl.style.display = 'none';
+    toggleBtn.textContent = 'Start Recording';
+  }
+}
 
-stopBtn.addEventListener('click', () => {
-  chrome.runtime.sendMessage({ type: 'stopRecording' });
-  currentName = null;
-  setTimeout(loadList, 200);
+toggleBtn.addEventListener('click', () => {
+  if (!recording) {
+    const name = prompt('Scenario name?');
+    if (!name) return;
+    currentName = name;
+    chrome.runtime.sendMessage({ type: 'startRecording', name });
+    recording = true;
+  } else {
+    chrome.runtime.sendMessage({ type: 'stopRecording' });
+    recording = false;
+    currentName = null;
+    setTimeout(loadList, 200);
+  }
+  updateRecordingUI();
 });
 
 addWaitBtn.addEventListener('click', () => {
@@ -45,6 +61,46 @@ addCopyBtn.addEventListener('click', () => {
   });
 });
 
+newScenarioBtn.addEventListener('click', () => {
+  const name = prompt('Scenario name?');
+  if (name) {
+    saveScenario(name, []);
+    loadList();
+  }
+});
+
+importBtn.addEventListener('click', () => importInput.click());
+
+importInput.addEventListener('change', (e) => {
+  const file = e.target.files && e.target.files[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = () => {
+    try {
+      const obj = JSON.parse(reader.result);
+      if (obj.name && Array.isArray(obj.steps)) {
+        saveScenario(obj.name, obj.steps);
+        loadList();
+      } else {
+        alert('Invalid scenario file');
+      }
+    } catch (err) {
+      alert('Failed to import scenario');
+    }
+  };
+  reader.readAsText(file);
+  importInput.value = '';
+});
+
+function exportScenario(name, steps) {
+  const data = JSON.stringify({ name, steps }, null, 2);
+  const url = 'data:text/json;charset=utf-8,' + encodeURIComponent(data);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = name.replace(/\s+/g, '_') + '.json';
+  a.click();
+}
+
 function runScenario(name) {
   chrome.runtime.sendMessage({ type: 'runScenario', name });
 }
@@ -68,19 +124,33 @@ function editScenario(name, steps) {
 
 function createItem(name, steps) {
   const li = document.createElement('li');
-  li.textContent = name + ' ';
+  li.className = 'scenario-item';
+  const span = document.createElement('span');
+  span.textContent = name;
+  const actions = document.createElement('div');
+  actions.className = 'actions';
+
   const run = document.createElement('button');
   run.textContent = 'Run';
   run.onclick = () => runScenario(name);
   const edit = document.createElement('button');
   edit.textContent = 'Edit';
   edit.onclick = () => editScenario(name, steps);
+  const exp = document.createElement('button');
+  exp.textContent = 'Export';
+  exp.onclick = () => exportScenario(name, steps);
   const del = document.createElement('button');
+  del.className = 'delete-btn';
   del.textContent = 'Delete';
   del.onclick = () => deleteScenario(name);
-  li.appendChild(run);
-  li.appendChild(edit);
-  li.appendChild(del);
+
+  actions.appendChild(run);
+  actions.appendChild(edit);
+  actions.appendChild(exp);
+  actions.appendChild(del);
+
+  li.appendChild(span);
+  li.appendChild(actions);
   return li;
 }
 
@@ -94,3 +164,4 @@ function loadList() {
 }
 
 loadList();
+updateRecordingUI();

--- a/extension/styles.css
+++ b/extension/styles.css
@@ -1,1 +1,343 @@
-body { font-family: sans-serif; padding: 10px; }
+:root {
+    --bg-color: #1a1a1a;
+    --text-color: #f0f0f0;
+    --primary-color: #00aaff;
+    --primary-hover: #0088cc;
+    --secondary-color: #4CAF50;
+    --secondary-hover: #45a049;
+    --danger-color: #e63946;
+    --danger-hover: #c9303c;
+    --surface-color: #2a2a2a;
+    --surface-color-light: #3a3a3a;
+    --border-color: #444;
+    --success-color: #2a9d8f;
+    --error-color: var(--danger-color);
+    --running-color: #e9c46a;
+}
+
+body {
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+}
+
+.container {
+    padding: 16px;
+    height: 100%;
+}
+
+.header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 1px solid var(--border-color);
+    padding-bottom: 12px;
+    margin-bottom: 16px;
+}
+
+.header h1 {
+    font-size: 1.2rem;
+    margin: 0;
+}
+
+button, .button {
+    background-color: var(--primary-color);
+    color: white;
+    border: none;
+    padding: 8px 12px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-weight: bold;
+    transition: background-color 0.2s;
+    text-decoration: none;
+    display: inline-block;
+    text-align: center;
+}
+
+button:hover, .button:hover {
+    background-color: var(--primary-hover);
+}
+
+button:disabled {
+    background-color: #555;
+    cursor: not-allowed;
+}
+
+.button-secondary {
+    background-color: var(--secondary-color);
+}
+.button-secondary:hover {
+    background-color: var(--secondary-hover);
+}
+
+.button-danger {
+    background-color: var(--danger-color);
+}
+.button-danger:hover {
+    background-color: var(--danger-hover);
+}
+
+.record-button-wrapper {
+    margin-bottom: 16px;
+}
+
+.record-button {
+    width: 100%;
+    padding: 12px;
+}
+
+.recording-status {
+    background-color: var(--danger-color);
+    color: white;
+    text-align: center;
+    padding: 8px;
+    border-radius: 4px;
+    margin-bottom: 16px;
+    font-weight: bold;
+}
+
+.scenario-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.scenario-item {
+    background-color: var(--surface-color);
+    padding: 12px;
+    border-radius: 6px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.scenario-item span {
+    font-weight: 500;
+}
+
+.scenario-item .actions {
+    display: flex;
+    gap: 8px;
+    flex-shrink: 0;
+}
+
+.actions button {
+    font-size: 0.75rem;
+    padding: 6px 8px;
+    background-color: var(--surface-color);
+    border: 1px solid var(--primary-color);
+    color: var(--primary-color);
+}
+
+.actions button:hover {
+     background-color: rgba(0, 170, 255, 0.1);
+}
+
+.actions .delete-btn {
+    border-color: var(--danger-color);
+    color: var(--danger-color);
+}
+.actions .delete-btn:hover {
+    background-color: rgba(230, 57, 70, 0.1);
+}
+
+
+/* Editor Styles */
+.editor-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 8px;
+}
+.editor-header h2 {
+    font-size: 1.1rem;
+    margin: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    padding: 0 10px;
+}
+
+.run-status {
+    text-align: center;
+    padding: 6px;
+    margin-bottom: 12px;
+    border-radius: 4px;
+    font-weight: 500;
+    transition: background-color 0.3s;
+}
+.run-status.idle { background-color: var(--surface-color-light); }
+.run-status.running { background-color: var(--running-color); color: #1a1a1a; }
+.run-status.success { background-color: var(--success-color); }
+.run-status.error { background-color: var(--error-color); }
+
+.form-group {
+    margin-bottom: 16px;
+}
+
+.form-group label {
+    display: block;
+    margin-bottom: 8px;
+    font-weight: bold;
+    color: #ccc;
+}
+
+.form-group input {
+    width: 100%;
+    padding: 10px;
+    background-color: var(--surface-color);
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    color: var(--text-color);
+    box-sizing: border-box;
+}
+
+.block-list {
+    list-style: none;
+    padding: 0;
+    margin: 16px 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    max-height: 250px;
+    overflow-y: auto;
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    padding: 8px;
+}
+
+.block-list-item {
+    cursor: grab;
+}
+.block-list-item:active {
+    cursor: grabbing;
+}
+
+.block-item-wrapper {
+    background-color: var(--surface-color);
+    border-radius: 4px;
+    margin-bottom: 4px;
+}
+
+.block-item {
+    padding: 8px 10px;
+    font-family: 'SF Mono', 'Courier New', monospace;
+    font-size: 0.85rem;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    position: relative;
+    border-left: 4px solid transparent;
+    transition: border-color 0.3s;
+}
+.block-item.status-running { border-left-color: var(--running-color); }
+.block-item.status-success { border-left-color: var(--success-color); }
+.block-item.status-error { border-left-color: var(--error-color); }
+
+.status-icon {
+    font-size: 0.7rem;
+    width: 16px;
+    text-align: center;
+}
+
+.block-item .type {
+    font-weight: bold;
+    color: var(--primary-color);
+    flex-shrink: 0;
+}
+.block-item .details {
+    color: #ddd;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    flex-grow: 1;
+}
+.no-blocks {
+    color: #888;
+    text-align: center;
+    padding: 20px;
+}
+
+.delete-block-btn {
+    background: none;
+    border: none;
+    color: var(--danger-color);
+    cursor: pointer;
+    font-size: 1.2rem;
+    padding: 0 5px;
+    opacity: 0.5;
+    transition: opacity 0.2s;
+}
+.block-item:hover .delete-block-btn {
+    opacity: 1;
+}
+
+.nested-container {
+    padding-left: 20px;
+}
+.nested-branch {
+    border-left: 2px solid var(--border-color);
+    padding: 4px 8px;
+    margin: 4px 0;
+    background-color: rgba(0,0,0,0.1);
+}
+.nested-branch strong {
+    color: var(--primary-color);
+    font-size: 0.8rem;
+}
+.nested-blocks {
+    padding-left: 10px;
+    font-style: italic;
+    color: #aaa;
+    font-size: 0.8rem;
+}
+
+
+/* Add Step Form */
+.add-step-form {
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    padding: 12px;
+    margin-top: 16px;
+}
+
+.add-step-form h4 {
+    margin: 0 0 10px 0;
+    color: #ccc;
+}
+
+.add-step-form .form-row {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 8px;
+}
+.add-step-form select {
+    flex-grow: 1;
+    padding: 8px;
+    background-color: var(--surface-color);
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    color: var(--text-color);
+}
+.add-step-form button {
+    flex-shrink: 0;
+}
+.add-step-form .form-fields {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+.add-step-form .form-fields input {
+    width: 100%;
+    padding: 8px;
+    background-color: var(--surface-color);
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    color: var(--text-color);
+    box-sizing: border-box;
+    font-size: 0.85rem;
+}


### PR DESCRIPTION
## Summary
- apply the more complete popup styling from reference
- redesign popup.html layout with header, buttons, and scenario list
- expand popup.js to handle new UI controls such as import/export and recording toggle

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6868687b6d54833188056d2e9bd4d155