### PR TITLE
Improve element selection accuracy

### DIFF
--- a/scripts/background.js
+++ b/scripts/background.js
@@ -112,6 +112,11 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
             sendResponse({ success: true });
         },
         elementSelected: async (request) => {
+            if (!request || !request.elementData) {
+                console.warn("Background: elementSelected called without elementData", request);
+                sendResponse({ success: false });
+                return;
+            }
             console.log("Background: Received elementSelected message with elementData:", request.elementData);
             const currentState = await getInitialAppState();
             // Safely access elementData, default to null if undefined

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -37,7 +37,15 @@
             document.removeEventListener('click', secimModu.elementiSec, { capture: true });
         },
         elementiVurgula: (e) => {
-            const hedef = e.target;
+            const interactiveTags = ['INPUT', 'TEXTAREA', 'SELECT', 'BUTTON', 'A'];
+            let hedef = e.target;
+
+            const elementsAtPoint = document.elementsFromPoint(e.clientX, e.clientY);
+            const deeperInteractive = elementsAtPoint.find(el => interactiveTags.includes(el.tagName));
+            if (deeperInteractive) {
+                hedef = deeperInteractive;
+            }
+
             secimModu.vurgulamayiKaldir();
             hedef.classList.add('sisypi-secim-icin-vurgula');
             sonVurgulananElement = hedef;
@@ -52,20 +60,12 @@
             e.preventDefault();
             e.stopPropagation();
 
-            let targetElement = e.target;
-            // Try to find the closest interactive element
             const interactiveTags = ['INPUT', 'TEXTAREA', 'SELECT', 'BUTTON', 'A'];
-            
-            // Prioritize the clicked element itself if it's interactive
-            if (!interactiveTags.includes(targetElement.tagName) && targetElement.parentElement) {
-                let current = e.target.parentElement;
-                while (current && current !== document.body) {
-                    if (interactiveTags.includes(current.tagName)) {
-                        targetElement = current;
-                        break;
-                    }
-                    current = current.parentElement;
-                }
+            let targetElement = e.target;
+            const elementsAtPoint = document.elementsFromPoint(e.clientX, e.clientY);
+            const deeperInteractive = elementsAtPoint.find(el => interactiveTags.includes(el.tagName));
+            if (deeperInteractive) {
+                targetElement = deeperInteractive;
             }
 
             const secici = secimModu.cssSeciciOlustur(targetElement);


### PR DESCRIPTION
## Summary
- refine element highlighter to consider deeper interactive elements
- use same logic when sending selected element data
- guard against undefined element data in background script

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: Could not resolve entry module)*
- `npm run dev` *(started Vite dev server)*

------
https://chatgpt.com/codex/tasks/task_b_686a6ec3f4148331afc499cc57ab8cc1