### PR TITLE
This commit introduces a robust, Node.js-based build script (`scripts…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,12 +20,16 @@ This is a Chrome browser extension built with a modern tech stack. The architect
 
 ## Build Process
 
-The project uses **Vite** to build the React popup.
+The project uses a custom Node.js script to manage the build process, which in turn uses Vite to build the React popup.
 
--   **Configuration File:** `vite.config.cjs`
--   **To build the project, you MUST run:** `npm run build`
+-   **Build Script:** `scripts/build.cjs`
+-   **Vite Configuration:** `vite.config.cjs`
 
-This command will compile the `index.tsx` and all related files and place the final, loadable extension into the `/dist` directory. The `/dist` directory is what you should load as an "unpacked extension" in Chrome for testing.
+**Key `npm` commands:**
+-   `npm run build`: This is the main command to build the extension. It cleans the `dist` folder, runs Vite, and copies all necessary static files, preparing the extension for loading.
+-   `npm run zip`: This command first runs the build process and then creates a `sisypi-extension.zip` file in the root directory, ready for distribution.
+
+The final, loadable extension is always located in the `/dist` directory.
 
 **IMPORTANT:** There have been significant, unresolvable issues with the `npm` environment in some sandboxes. The `npm install` command sometimes fails to create the `node_modules/.bin` directory, which prevents the `vite` command from being found. If you encounter build errors like `vite: not found`, this is likely the cause. This is an **environmental issue**, not a code issue.
 

--- a/README.md
+++ b/README.md
@@ -51,13 +51,19 @@ This project is developed using modern web development tools: **Vite, React, and
     ```bash
     npm run build
     ```
-4.  **Load the Extension in Chrome:**
+4.  **Create a Zipped Package (Optional):** To easily share or install the extension, you can create a zip file.
+    ```bash
+    npm run zip
+    ```
+    This will create a `sisypi-extension.zip` file in the root directory.
+
+5.  **Load the Extension in Chrome:**
     *   Open your Chrome browser and navigate to `chrome://extensions`.
     *   Enable the **"Developer mode"** toggle in the top right corner.
-    *   Click the **"Load unpacked"** button.
-    *   Select the **`dist`** folder that was created by the build process.
+    *   To load the extension for development, click **"Load unpacked"** and select the **`dist`** folder.
+    *   To install from the zip file, you can drag and drop the `sisypi-extension.zip` file onto the extensions page.
 
-The Sisypi extension will now be installed and ready to use. If you make changes to the source code, you must run `npm run build` again and then click the "reload" icon on the extension's card in the `chrome://extensions` page.
+The Sisypi extension will now be installed and ready to use. If you make changes to the source code, you must run `npm run build` (or `npm run zip`) again and then click the "reload" icon on the extension's card in the `chrome://extensions` page.
 
 ## Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@types/node": "^22.14.0",
         "@types/react": "^19.1.9",
         "@types/react-dom": "^19.1.7",
+        "fs-extra": "^11.3.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "typescript": "~5.7.2",
@@ -876,6 +877,21 @@
         }
       }
     },
+    "node_modules/fs-extra": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -889,6 +905,26 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/nanoid": {
@@ -1076,6 +1112,16 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/vite": {
       "version": "6.3.5",

--- a/package.json
+++ b/package.json
@@ -5,14 +5,16 @@
   "type": "module",
   "scripts": {
     "dev": "npx vite",
-    "build": "npx vite build",
-    "preview": "npx vite preview"
+    "build": "node scripts/build.cjs",
+    "preview": "npx vite preview",
+    "zip": "npm run build && (cd dist && zip -r ../sisypi-extension.zip .)"
   },
   "devDependencies": {
     "@types/chrome": "^0.1.1",
     "@types/node": "^22.14.0",
     "@types/react": "^19.1.9",
     "@types/react-dom": "^19.1.7",
+    "fs-extra": "^11.3.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "typescript": "~5.7.2",

--- a/scripts/build.cjs
+++ b/scripts/build.cjs
@@ -1,0 +1,63 @@
+const fs = require('fs-extra');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const distDir = path.join(__dirname, '../dist');
+const rootDir = path.join(__dirname, '..');
+const viteBin = path.join(rootDir, 'node_modules', '.bin', 'vite');
+
+async function build() {
+  try {
+    // Pre-flight check for Vite binary
+    if (!fs.existsSync(viteBin)) {
+      console.error('================================================================');
+      console.error('FATAL: Vite executable not found at the expected path:');
+      console.error(viteBin);
+      console.error('\nThis indicates that `npm install` did not create the binary links.');
+      console.error('This is a known issue in some sandboxed environments.');
+      console.error('The build cannot continue.');
+      console.error('================================================================');
+      process.exit(1);
+    }
+
+    // 1. Clear the dist directory
+    console.log('Cleaning dist directory...');
+    await fs.emptyDir(distDir);
+
+    // 2. Run Vite build for the popup
+    console.log('Building popup with Vite...');
+    // Use the direct path to avoid PATH issues with npx/sh
+    execSync(`"${viteBin}" build`, { stdio: 'inherit', cwd: rootDir });
+
+    // 3. Copy static assets
+    console.log('Copying static assets...');
+    const assets = ['scripts', 'content', 'icons', 'lib'];
+    for (const asset of assets) {
+      const sourcePath = path.join(rootDir, asset);
+      if (fs.existsSync(sourcePath)) {
+        await fs.copy(sourcePath, path.join(distDir, asset));
+      }
+    }
+
+    // 4. Read, modify, and write manifest.json
+    console.log('Processing manifest.json...');
+    const manifestPath = path.join(rootDir, 'manifest.json');
+    const manifest = await fs.readJson(manifestPath);
+
+    // Modify paths for the dist folder
+    manifest.action.default_popup = 'popup.html';
+
+    const distManifestPath = path.join(distDir, 'manifest.json');
+    await fs.writeJson(distManifestPath, manifest, { spaces: 2 });
+
+    console.log('\n✅ Extension build complete!');
+    console.log(`Ready to be loaded from: ${distDir}`);
+
+  } catch (error) {
+    console.error('\n❌ Build failed:');
+    console.error(error);
+    process.exit(1);
+  }
+}
+
+build();


### PR DESCRIPTION
…/build.cjs`) that handles the entire process of preparing the extension for use:

- Clears the `dist` directory.
- Builds the React popup using Vite.
- Copies all necessary static assets (`scripts`, `content`, `icons`, `lib`).
- Correctly modifies `manifest.json` with the proper paths for the built extension, fixing the critical bug where the popup would not open.

A new `npm run zip` command has been added to create a distributable zip file of the extension.

All documentation (`README.md` and `AGENTS.md`) has been updated to reflect the new build process and project structure.